### PR TITLE
Remove redundant setup instructions and clarify exercise headings in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-Aqui está o Markdown aprimorado com os enunciados dos exercícios organizados de forma clara e estruturada para o seu
-repositório no GitHub:
-
----
-
 # Target Sistemas
 
 Este repositório contém uma série de exercícios em Python desenvolvidos como parte de um processo seletivo para a Target
@@ -15,7 +10,6 @@ Sistemas.
 - [Exercício 3](#exercício-3)
 - [Exercício 4](#exercício-4)
 - [Exercício 5](#exercício-5)
-- [Requisitos e Configuração](#requisitos-e-configuração)
 
 ## Exercícios e Saídas
 
@@ -122,51 +116,3 @@ Escreva um programa que inverta os caracteres de um string.
 Arquivo: [`ex05.py`](ex05.py)  
 Saída:  
 ![Saída do Ex05](output/ex05.png)
-
-## Requisitos e Configuração
-
-Para executar os arquivos deste repositório, é necessário ter os seguintes requisitos instalados:
-
-- Python 3.12+
-- [Poetry](https://python-poetry.org/) para gerenciamento de dependências
-
-### Instalação de Dependências
-
-Certifique-se de que o `Poetry` esteja instalado em seu ambiente. Para instalar o `Poetry`, siga as instruções
-em [python-poetry.org](https://python-poetry.org/docs/#installation).
-
-Depois de instalar o `Poetry`, siga as etapas abaixo:
-
-1. Clone o repositório para o seu ambiente local:
-
-   ```bash
-   git clone https://github.com/bysedd/target-sistemas.git
-   cd target-sistemas
-   ```
-
-2. Instale as dependências usando o `Poetry`:
-
-   ```bash
-   poetry install
-   ```
-
-   Isso instalará todas as dependências listadas nos grupos `[tool.poetry.dependencies]` e
-   `[tool.poetry.group.dev.dependencies]` do arquivo `pyproject.toml`.
-
-3. Para executar qualquer um dos scripts, utilize o comando:
-
-   ```bash
-   poetry run python nome_do_arquivo.py
-   ```
-
-### Configuração de Ambiente
-
-- Este projeto usa o `mypy` para verificação de tipos e o `ruff` para linting. As configurações estão definidas no
-  arquivo `pyproject.toml`:
-
-   ```toml
-   [tool.mypy]
-   python_version = "3.12"
-   strict = true
-   ignore_missing_imports = true
-   ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Sistemas.
 
 ### Exercício 1
 
-#### Enunciado
+#### Enunciado do Exercício 1
 
 Observe o trecho de código abaixo:
 
@@ -34,7 +34,7 @@ Imprimir(SOMA);
 
 Ao final do processamento, qual será o valor da variável `SOMA`?
 
-#### Arquivo e Saída
+#### Arquivo e Saída do Exercício 1
 
 Arquivo: [`ex01.py`](ex01.py)  
 Saída:  
@@ -42,13 +42,13 @@ Saída:
 
 ### Exercício 2
 
-#### Enunciado
+#### Enunciado do Exercício 2
 
 Dado a sequência de Fibonacci, onde se inicia por 0 e 1 e o próximo valor sempre será a soma dos 2 valores anteriores (
 exemplo: 0, 1, 1, 2, 3, 5, 8, 13, 21, 34...), escreva um programa na linguagem que desejar onde, informado um número,
 ele calcule a sequência de Fibonacci e retorne uma mensagem avisando se o número informado pertence ou não à sequência.
 
-#### Arquivo e Saída
+#### Arquivo e Saída do Exercício 2
 
 Arquivo: [`ex02.py`](ex02.py)  
 Saídas:  
@@ -57,7 +57,7 @@ Saídas:
 
 ### Exercício 3
 
-#### Enunciado
+#### Enunciado do Exercício 3
 
 Dado um vetor que guarda o valor de faturamento diário de uma distribuidora, faça um programa, na linguagem que desejar,
 que calcule e retorne:
@@ -72,7 +72,7 @@ que calcule e retorne:
 - b) Podem existir dias sem faturamento, como nos finais de semana e feriados. Estes dias devem ser ignorados no cálculo
   da média.
 
-#### Arquivo e Saída
+#### Arquivo e Saída do Exercício 3
 
 Arquivo: [`ex03.py`](ex03.py)  
 Saída:  
@@ -80,7 +80,7 @@ Saída:
 
 ### Exercício 4
 
-#### Enunciado
+#### Enunciado do Exercício 4
 
 Dado o valor de faturamento mensal de uma distribuidora, detalhado por estado:
 
@@ -93,7 +93,7 @@ Dado o valor de faturamento mensal de uma distribuidora, detalhado por estado:
 Escreva um programa na linguagem que desejar onde calcule o percentual de representação que cada estado teve dentro do
 valor total mensal da distribuidora.
 
-#### Arquivo e Saída
+#### Arquivo e Saída do Exercício 4
 
 Arquivo: [`ex04.py`](ex04.py)  
 Saída:  
@@ -101,7 +101,7 @@ Saída:
 
 ### Exercício 5
 
-#### Enunciado
+#### Enunciado do Exercício 5
 
 Escreva um programa que inverta os caracteres de um string.
 
@@ -111,7 +111,7 @@ Escreva um programa que inverta os caracteres de um string.
   código;
 - b) Evite usar funções prontas, como, por exemplo, `reverse`.
 
-#### Arquivo e Saída
+#### Arquivo e Saída do Exercício 5
 
 Arquivo: [`ex05.py`](ex05.py)  
 Saída:  


### PR DESCRIPTION
This pull request enhances the README by removing redundant setup instructions that were unnecessary for users. Additionally, it improves the clarity of the exercise instructions by specifying the exercise number in the headings, making it easier for users to navigate and understand the content. These changes aim to streamline the documentation and enhance user experience.